### PR TITLE
Compile latest luajit from git repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
     curl-dev \
     doxygen \
     gettext-dev \
+    git \
     gmp-dev \
     hiredis-dev \
     icu-dev \
@@ -36,7 +37,6 @@ RUN \
     libtool \
     libvorbis-dev \
     libxi-dev \
-    luajit-dev \
     mesa-dev \
     ncurses-dev \
     ninja-build \
@@ -56,13 +56,17 @@ RUN \
     libintl \
     libpq \
     libstdc++ \
-    luajit \
     lua-socket \
     sdl2 \
     sqlite \
     sqlite-libs \
     zstd \
     zstd-libs && \
+  echo "**** compile latest luajit ****" && \
+  git clone https://luajit.org/git/luajit.git && \
+  cd luajit && \
+  make amalg PREFIX=/usr && \
+  make install PREFIX=/usr && \
   echo "**** compile prometheus-cpp ****" && \
   mkdir -p /tmp/prometheus-cpp && \
   PROM_URL=$(curl -sX GET "https://api.github.com/repos/jupp0r/prometheus-cpp/releases/latest" \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,6 +25,7 @@ RUN \
     curl-dev \
     doxygen \
     gettext-dev \
+    git \
     gmp-dev \
     hiredis-dev \
     icu-dev \
@@ -36,7 +37,6 @@ RUN \
     libtool \
     libvorbis-dev \
     libxi-dev \
-    luajit-dev \
     mesa-dev \
     ncurses-dev \
     ninja-build \
@@ -56,13 +56,17 @@ RUN \
     libintl \
     libpq \
     libstdc++ \
-    luajit \
     lua-socket \
     sdl2 \
     sqlite \
     sqlite-libs \
     zstd \
     zstd-libs && \
+  echo "**** compile latest luajit ****" && \
+  git clone https://luajit.org/git/luajit.git && \
+  cd luajit && \
+  make amalg PREFIX=/usr && \
+  make install PREFIX=/usr && \
   echo "**** compile prometheus-cpp ****" && \
   mkdir -p /tmp/prometheus-cpp && \
   PROM_URL=$(curl -sX GET "https://api.github.com/repos/jupp0r/prometheus-cpp/releases/latest" \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -82,5 +82,6 @@ init_diagram: |
   "luanti:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.11.25:", desc: "Use latest LuaJIT from git to fix math bugs"}
   - {date: "09.07.25:", desc: "Rebase to Alpine 3.22."}
   - {date: "30.01.25:", desc: "Initial Release."}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-luanti/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The LuaJIT that is compiled on alpine has some math bugs that have been solved in the git LuaJIT. 

These bugs are preventing Luanti to start when using some games that make good use of the JIT component.

For example, trying to start latest game mineclonia with the latest luanti image on ARM fails with this error:
```
2025-10-28 04:29:29: ACTION[Main]: Server: Shutting down
2025-10-28 04:29:29: ERROR[Main]: ModError: Failed to load and run script from /config/.minetest/games/mineclonia/mods/MAPGEN/mcl_levelgen/init.lua:
2025-10-28 04:29:29: ERROR[Main]: ...est/games/mineclonia/mods/MAPGEN/mcl_levelgen/random.lua:857: assertion failed!
2025-10-28 04:29:29: ERROR[Main]: stack traceback:
2025-10-28 04:29:29: ERROR[Main]:        [C]: in function 'assert'
2025-10-28 04:29:29: ERROR[Main]:        ...est/games/mineclonia/mods/MAPGEN/mcl_levelgen/random.lua:857: in main chunk
2025-10-28 04:29:29: ERROR[Main]:        [C]: in function 'dofile'
2025-10-28 04:29:29: ERROR[Main]:        ...etest/games/mineclonia/mods/MAPGEN/mcl_levelgen/init.lua:168: in main chunk
```

## Benefits of this PR and context:
Using latest LuaJIT from git fixes these bugs.

## How Has This Been Tested?
Have built the docker image on my Raspberry Pi 4 and checked that the errors reported before are gone.

## Source / References:
* https://codeberg.org/mineclonia/mineclonia/issues/3739
